### PR TITLE
Fix gallery.yaml images

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -1,7 +1,7 @@
 - name: eChem: Computational Chemistry from Laptop to HPC
   website: https://kthpanor.github.io/echem/
   repository: https://github.com/kthpanor/echem
-  image: https://github.com/kthpanor/echem/raw/master/logo.png
+  image: https://raw.githubusercontent.com/kthpanor/echem/master/logo.png
 - name: Data Science for Finance
   website: https://ledatascifi.github.io
   repository: https://github.com/LeDataSciFi/ledatascifi-2022
@@ -13,7 +13,7 @@
 - name: The Data Science Interview Book
   website: https://dipranjan.github.io/dsinterviewqns/intro.html
   repository: https://github.com/dipranjan/dsinterviewqns
-  image: https://github.com/dipranjan/dsinterviewqns/raw/master/logo.gif
+  image: https://raw.githubusercontent.com/dipranjan/dsinterviewqns/master/logo.gif
 - name: Coding for Economists
   website: https://aeturrell.github.io/coding-for-economists
   repository: https://github.com/aeturrell/coding-for-economists
@@ -93,15 +93,15 @@
 - name: Machine Learning, Statistics, and Data Mining for Heliophysics
   website: https://helioml.org
   repository: https://github.com/HelioML/HelioML/
-  image: https://github.com/HelioML/HelioML/raw/master/book/logo.png
+  image: https://raw.githubusercontent.com/HelioML/HelioML/master/book/logo.png
 - name: Earth and Environmental Data Science
   website: http://earth-env-data-science.github.io/
   repository: https://github.com/earth-env-data-science/earth-env-data-science-book
-  image: https://github.com/earth-env-data-science/earth-env-data-science-book/raw/master/content/images/logo/enso_sst.png
+  image: https://raw.githubusercontent.com/earth-env-data-science/earth-env-data-science-book/master/content/images/logo/enso_sst.png
 - name: DartBrains
   website: https://dartbrains.org/
   repository: https://github.com/ljchang/dartbrains
-  image: https://github.com/ljchang/dartbrains/raw/master/images/logo/dartbrains_logo_square_transparent.png
+  image: https://raw.githubusercontent.com/ljchang/dartbrains/master/images/logo/dartbrains_logo_square_transparent.png
 - name: Neuroimaging Analysis Methods for Naturalistic Data
   website: http://naturalistic-data.org/
   repository: https://github.com/naturalistic-data-analysis/naturalistic_data_analysis
@@ -113,7 +113,7 @@
 - name: "The Turing Way: A guide to reproducible, ethical, inclusive and collaborative data science"
   website: https://the-turing-way.netlify.app
   repository: https://github.com/alan-turing-institute/the-turing-way
-  image: https://github.com/alan-turing-institute/the-turing-way/raw/master/book/website/figures/logo/logo.png
+  image: https://raw.githubusercontent.com/alan-turing-institute/the-turing-way/master/book/website/figures/logo/logo.png
 - name: Deep Learning for Molecules and Materials
   website: https://whitead.github.io/dmol-book/
   repository: https://github.com/whitead/dmol-book
@@ -140,7 +140,7 @@
   website: https://kyleniemeyer.github.io/computational-thermo
 - name: "Make Use of Data: Data Science Notes"
   repository: https://github.com/wyattowalsh/data-science-notes
-  image: https://github.com/wyattowalsh/data-science-notes/raw/master/data-science-notes/favicon_io/apple-touch-icon.png
+  image: https://raw.githubusercontent.com/wyattowalsh/data-science-notes/master/data-science-notes/favicon_io/apple-touch-icon.png
   website: https://makeuseofdata.com
 - name: "Guide de bonnes pratiques sur les données de la recherche"
   repository: https://github.com/miti-gt-donnees/guide.git
@@ -237,7 +237,7 @@
 - name: Computational Models of Human Social Behavior & Neuroscience
   website: https://shawnrhoads.github.io/gu-psyc-347
   repository: https://github.com/shawnrhoads/gu-psyc-347
-  image: https://github.com/shawnrhoads/gu-psyc-347/raw/master/docs/static/images/logo-background.jpg
+  image: https://raw.githubusercontent.com/shawnrhoads/gu-psyc-347/master/docs/static/images/logo-background.jpg
 - name: Foundations of Data Science with Python
   website: https://jmshea.github.io/Foundations-of-Data-Science-with-Python
   repository: https://github.com/jmshea/Foundations-of-Data-Science-with-Python
@@ -261,7 +261,7 @@
 - name: "Music Classification: Beyond Supervised Learning, Towards Real-world Applications"
   website: https://music-classification.github.io/tutorial/
   repository: https://github.com/music-classification/tutorial
-  image: https://github.com/music-classification/tutorial/raw/main/book/images/favicon_io/android-chrome-512x512.png
+  image: https://raw.githubusercontent.com/music-classification/tutorial/main/book/images/favicon_io/android-chrome-512x512.png
 - name: "PyMedPhys: Supporting Medical Physicists in making radiotherapy cancer treatment safer"
   website: https://docs.pymedphys.com/
   repository: https://github.com/pymedphys/pymedphys/tree/main/lib/pymedphys/docs
@@ -281,7 +281,7 @@
 - name: "Quality Assurance of Code for Analysis and Research"
   website: https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html
   repository: https://github.com/best-practice-and-impact/qa-of-code-guidance
-  image: https://github.com/best-practice-and-impact/qa-of-code-guidance/blob/master/book/_static/duck_book_logo.svg
+  image: https://raw.githubusercontent.com/best-practice-and-impact/qa-of-code-guidance/master/book/_static/duck_book_logo.svg
 - name: "Network Data Science"
   website: https://bdpedigo.github.io/networks-course
   repository: https://github.com/bdpedigo/networks-course
@@ -317,8 +317,8 @@
 - name: "Classifying 19th Century British Library books using Crowdsourcing and Machine Learning"
   website: https://living-with-machines.github.io/genre-classification/
   repository: https://github.com/Living-with-machines/genre-classification
-  image: https://github.com/Living-with-machines/genre-classification/blob/main/genre_classification_of_bl_books/logo.jpg?raw=true
+  image: https://raw.githubusercontent.com/Living-with-machines/genre-classification/main/genre_classification_of_bl_books/logo.jpg?raw=true
 - name: "pyhf User Guide and Tutorial"
   website: https://pyhf.github.io/pyhf-tutorial/
   repository: https://github.com/pyhf/pyhf-tutorial
-  image: https://github.com/scikit-hep/pyhf/raw/master/docs/_static/img/pyhf-logo.png
+  image: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/pyhf-logo.png


### PR DESCRIPTION
Many images are broken in the gallery because they refer to github.com rather than raw.githubusercontent.com. Fix.